### PR TITLE
Add Gradle repositories for buildscript dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,10 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
     }
+    repositories {
+        jcenter()
+        google()
+    }
 }
 
 allprojects {


### PR DESCRIPTION
Hello,

When trying to build the app with Gradle, I get the following error:
```
A problem occurred configuring root project 'monkeyboard-radio-android'.
> Could not resolve all files for configuration ':classpath'.
   > Cannot resolve external dependency com.android.tools.build:gradle:3.0.1 because no repositories are defined.
     Required by:
         project :
```

This pull request fixes it.